### PR TITLE
docs: add H2 2023 roadmap

### DIFF
--- a/.github/workflows/roadmap.yml
+++ b/.github/workflows/roadmap.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - ROADMAP.md
       - .github/workflows/roadmap.yml

--- a/.github/workflows/roadmap.yml
+++ b/.github/workflows/roadmap.yml
@@ -1,9 +1,11 @@
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - ROADMAP.md
+      - .github/workflows/roadmap.yml
+  workflow_dispatch:
 
 defaults:
   run:
@@ -16,17 +18,15 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            const owner = github.context.repo.owner;
-            const repo = github.context.repo.repo;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
 
             const issues = await github.paginate(github.rest.issues.listForRepo, {owner, repo});
 
             const fs = require('fs');
-            const path = require('path');
+            const roadmap = fs.readFileSync('ROADMAP.md', 'utf8');
 
-            const roadmapPath = path.join(github.workspace, 'ROADMAP.md');
-            const roadmap = fs.readFileSync(roadmapPath, 'utf8');
-
+            var issue
             var title = ''
             var body = ''
 
@@ -35,7 +35,7 @@ jobs:
               if (line.startsWith('## ')) {
                 if (title) {
                   const link = title.toLowerCase().replace(/[\s]/g, '-').replace(/[^\w-]/g, '');
-                  body = `description: https://github.com/${owner}/${repo}/blob/main/ROADMAP.md#${link}\n` +
+                  body = `description: https://github.com/${owner}/${repo}/blob/master/ROADMAP.md#${link}\n\n` +
                     `---\n\n${body}`;
                   milestones.push({ title, body });
                 }
@@ -51,44 +51,47 @@ jobs:
 
             const children = []
             for (const {title, body} of milestones) {
-              var issue = issues.find(issue => issue.title === title);
+              issue = issues.find(issue => issue.title === title);
               if (issue) {
                 await github.rest.issues.update({
-                  owner: github.context.repo.owner,
-                  repo: github.context.repo.repo,
+                  owner,
+                  repo,
                   issue_number: issue.number,
                   body: `${issue.body.split('---')[0]}\n---\n${body}`,
+                  labels: ['starmaps'],
                 });
               } else {
-                issue = await github.rest.issues.create({
-                  owner: github.context.repo.owner,
-                  repo: github.context.repo.repo,
+                issue = (await github.rest.issues.create({
+                  owner,
+                  repo,
                   title,
-                  body: `---\n\n${body}`,
-                });
+                  body: `<!-- The content above will **NOT** be modified by automation. -->\n\n---\n\n${body}`,
+                  labels: ['starmaps'],
+                })).data;
               }
               children.push(issue.html_url);
             }
 
             title = roadmap.split('\n')[0].replace('# ', '');
-            body = `description: https://github.com/${owner}/${repo}/blob/main/ROADMAP.md\n` +
+            body = `description: https://github.com/${owner}/${repo}/blob/master/ROADMAP.md\n` +
               `children:\n${children.map(child => `  - ${child}`).join('\n')}\n` +
-              `---\n\n${roadmap};
+              `---\n\n${roadmap}`;
 
-            var issue = issues.find(issue => issue.title === title);
+            issue = issues.find(issue => issue.title === title);
             if (issue) {
               await github.rest.issues.update({
-                owner: github.context.repo.owner,
-                repo: github.context.repo.repo,
+                owner,
+                repo,
                 issue_number: issue.number,
                 body: issue.body.split('---')[0] + '\n---\n' + body,
+                labels: ['starmaps'],
               });
             } else {
-              issue = await github.rest.issues.create({
-                owner: github.context.repo.owner,
-                repo: github.context.repo.repo,
+              await github.rest.issues.create({
+                owner,
+                repo,
                 title,
-                body: '---\n\n' + body,
+                body: '<!-- The content above will **NOT** be modified by automation. -->\n\n---\n\n' + body,
                 labels: ['starmaps'],
               });
             }

--- a/.github/workflows/roadmap.yml
+++ b/.github/workflows/roadmap.yml
@@ -1,0 +1,94 @@
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ROADMAP.md
+
+defaults:
+  run:
+    shell: bash
+jobs:
+  roadmap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const owner = github.context.repo.owner;
+            const repo = github.context.repo.repo;
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {owner, repo});
+
+            const fs = require('fs');
+            const path = require('path');
+
+            const roadmapPath = path.join(github.workspace, 'ROADMAP.md');
+            const roadmap = fs.readFileSync(roadmapPath, 'utf8');
+
+            var title = ''
+            var body = ''
+
+            const milestones = []
+            for (const line of roadmap.split('\n')) {
+              if (line.startsWith('## ')) {
+                if (title) {
+                  const link = title.toLowerCase().replace(/[\s]/g, '-').replace(/[^\w-]/g, '');
+                  body = `description: https://github.com/${owner}/${repo}/blob/main/ROADMAP.md#${link}\n` +
+                    `---\n\n${body}`;
+                  milestones.push({ title, body });
+                }
+                title = line.replace('## ', '');
+                body = '';
+              } else {
+                body += `${line}\n`;
+              }
+            }
+            if (title) {
+              milestones.push({ title, body });
+            }
+
+            const children = []
+            for (const {title, body} of milestones) {
+              var issue = issues.find(issue => issue.title === title);
+              if (issue) {
+                await github.rest.issues.update({
+                  owner: github.context.repo.owner,
+                  repo: github.context.repo.repo,
+                  issue_number: issue.number,
+                  body: `${issue.body.split('---')[0]}\n---\n${body}`,
+                });
+              } else {
+                issue = await github.rest.issues.create({
+                  owner: github.context.repo.owner,
+                  repo: github.context.repo.repo,
+                  title,
+                  body: `---\n\n${body}`,
+                });
+              }
+              children.push(issue.html_url);
+            }
+
+            title = roadmap.split('\n')[0].replace('# ', '');
+            body = `description: https://github.com/${owner}/${repo}/blob/main/ROADMAP.md\n` +
+              `children:\n${children.map(child => `  - ${child}`).join('\n')}\n` +
+              `---\n\n${roadmap};
+
+            var issue = issues.find(issue => issue.title === title);
+            if (issue) {
+              await github.rest.issues.update({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                issue_number: issue.number,
+                body: issue.body.split('---')[0] + '\n---\n' + body,
+              });
+            } else {
+              issue = await github.rest.issues.create({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                title,
+                body: '---\n\n' + body,
+                labels: ['starmaps'],
+              });
+            }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-# H2 2023
+# IPDX Roadmap H2 2023
 
 Given our mode of operation and the fact that we are highly affected by current needs of teams, our H2 roadmap serves mainly us a guideline of where our interests lie and where we'd like to focus our efforts. We view our adaptability as one of our main strengths but it also means we have to be flexible when it comes to our planning. If you already know of things you'd like our involvement for in H2 2023, please let us know - we're happy to adjust accordingly. We're here for you ❤️
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,7 +46,7 @@ In August, we're going to release new version of Unified CI with Go 1.21 support
 - allowing configurability through dot files
 - simplifying enrollment with invite to deploy strategy
 
-All of the above will make Unified CI more robust, easier to manage and it will increase it chances to last for another couple of years. Moreover, it will open up doors for even more automation across hundreds of repositories, like using dependabot (instead of web3-bot that has to be maintained by IPDX) for Unified CI updates for example.
+All of the above will make Unified CI more robust, easier to manage and it will increase it chances to last for another couple of years. Moreover, it will open up doors for even more automation across hundreds of repositories, like using dependabot (instead of web3-bot that has to be maintained by IPDX) for Unified CI updates, or maintaining multiple variants of releaser workflows (e.g. release-please vs version.json vs PR).
 
 ## Immerse Into the Day to Day of IP JS Developer
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,84 @@
+# H2 2023
+
+Given our mode of operation and the fact that we are highly affected by current needs of teams, our H2 roadmap serves mainly us a guideline of where our interests lie and where we'd like to focus our efforts. We view our adaptability as one of our main strengths but it also means we have to be flexible when it comes to our planning. If you already know of things you'd like our involvement for in H2 2023, please let us know - we're happy to adjust accordingly. We're here for you ❤️
+
+## Drive GitHub Observability Usage Internally
+
+Whenever applicable, every project we start in H2 2023 should have a Grafana Dashboard associated with it that tracks relevant metrics for the project. Each project issue should have a link to the dashboard, description of the metrics we care about and the expected outcomes.
+
+Additionally, we'd like to use GitHub Observability to identify more workflows that would benefit from PL Self-Hosted Runners.
+
+## Release Gateway Conformance v1
+
+In H2 we want to conclude IPDX's active development of Gateway Conformance. Ideally, we'd like to attract Gateway implementation maintainers to become active contributors to the project. We're going to continue to serve as maintainers, review PRs and provide guidance.
+
+To be able to call Gateway Conformance ready for this, we should:
+- achieve test coverage parity with Kubo sharness tests
+- improve DX/UX around test expectations and names
+- start running Gateway Conformance against a gateway external to PL
+
+In terms of promotion of Gateway Conformance, we'd like to:
+- give a talk about Gateway Conformance during IPFS Camp
+- continue support of using Gateway Conformance in project Rhea
+
+As stretch goals for the Gateway Conformance initiative, we identified:
+- closer integration with specs repository/IPIP process
+- creation of dashboard encompassing all gateway implementations
+
+## Increase PL Self-Hosted Runners Relevance
+
+With the recent cost-reduction effort in the PL self-hosted runners space the project is well positioned to serve the needs of PL developers already. As of now there are 2 areas that we'd like to look more closely into:
+- windows runners (we already had them set up at the beginning so it's just a matter of resurrecting the configuration)
+- decreasing boot time (currently the runners take up to 2 minutes to boot up)
+
+## Expand IPDX Comms
+
+We want to continue living close to our developers. That's why we're going to continue releasing **What's new in GitHub?** issues on a monthly basis. What's more, we'd like to start a new regular newsletter about productivity tips. Finally, we'd like to start tracking [developer happiness](https://github.blog/2023-06-08-developer-experience-what-is-it-and-why-should-you-care/) among IP Stewards. To begin with, we're going to prepare surveys for IP Stewards developers that are going to be issued on a regular basis.
+
+When it comes to external comms, we'd like to actively participate in IPFS Camp and GitHub Universe conferences.
+
+## Release Unified CI 2.0
+
+In August, we're going to release new version of Unified CI with Go 1.21 support. With that release, we'd like to transition to [Unified CI 2.0](https://github.com/protocol/.github/issues/514) which should encompass all the learning that we gathered by running Unified CI in its' current form for years. This includes but is not limited to:
+- versioning Unified CI
+- embracing reusable workflows
+- centralising auomerge functionality
+- allowing configurability through dot files
+- simplifying enrollment with invite to deploy strategy
+
+All of the above will make Unified CI more robust, easier to manage and it will increase it chances to last for another couple of years. Moreover, it will open up doors for even more automation across hundreds of repositories, like using dependabot for Unified CI updates for example.
+
+## Immerse Into the Day to Day of IP JS Developer
+
+As one of the most underresourced projects within IP Stewards group, we think it is the best target for our research. We want to embed with the team for a while to uncover areas of potential DX improvements. By the end of this excercise we want to have a concrete, prioritised list of improvements that would make life of a IP JS developer easier.
+
+## Improve the Day to Day of Kubo/Boxo Developer
+
+We've been focusing on Kubo/Boxo developers in H1 2023. In H2, we'd like to work on the work items that we identified throughout the process. The main projects we envision are:
+- create a general solution for identifyin flaky tests within Go ecosystem
+- automate CHANGELOG update reminders
+- fix the shortcomings of testing and coverage at the cross section of Kubo and Boxo
+- deprecate sharness tests
+- execute kuboreleaser in GitHub Actions
+
+## Explore DX of Building on IPFS Stack
+
+Through our work on Gateway Conformance we discovered that building on IPFS stack is not easy, even for people close to the ecosystem. We'd like to start a standalone project that would help us explore this further. The very rough game plan is:
+1. Start a simple project that cuts through all the layers of IPFS stack (working idea - decentralised DropBox).
+2. Consume the publicly available documentation to implement the project.
+3. Document usability sharp edges and documentation shortcomings.
+4. Contribute usability fixes to the IPFS stack.
+
+Our thinking is that this exercise could attract more active contributors to the IPFS stack thus reducing strain on IP Stewards.
+
+This is a project that sparks joy for Laurent 💖
+
+## Increase GitHub Security
+
+We want to continue building up our partnership with RSS by continuous collaboration on Security Guides for Software Engineers. Moreover, we'd like to explore the possibility of:
+- deploying dependabot for updating GitHub Actions to all PL repositories
+- enabling Code Scanning with default settings in all PL repositories
+
+## R&D
+
+We want to continue bringing innovation and improvement to our development stack. To be able to do that, we need to be up-to-date with the latest tech in the field. We'll definitely continue exploring AI tooling throughout the rest of the year and evaluate its' relevance for our projects. Moreover, we'd like to gain practical experience with GitHub merge queues by integrating them in GitHub Management workflows.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,7 +50,7 @@ All of the above will make Unified CI more robust, easier to manage and it will 
 
 ## Immerse Into the Day to Day of IP JS Developer
 
-As one of the most underresourced projects within IP Stewards group, we think it is the best target for our research. We want to embed with the team for a while to uncover areas of potential DX improvements. By the end of this excercise we want to have a concrete, prioritised list of improvements that would make life of a IP JS developer easier.
+As one of the most under-resourced projects within IP Stewards group, it is the best target for our research. We want to embed with the team for a while to uncover areas of potential DX improvements. By the end of this exercise, we want to have a concrete, prioritised list of improvements that would make the life of a IP JS developer easier.
 
 ## Improve the Day to Day of Kubo/Boxo Developer
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ As stretch goals for the Gateway Conformance initiative, we identified:
 
 ## Increase PL Self-Hosted Runners Relevance
 
-With the recent cost-reduction effort in the PL self-hosted runners space the project is well positioned to serve the needs of PL developers already. As of now there are 2 areas that we'd like to look more closely into:
+With the recent $ cost reduction efforts in the PL self-hosted runners space the project is well positioned to serve the needs of PL developers already i.e. we feel confident it's the correct solution to apply to increase developer speed when faced with GitHub hosted runners bottleneck problem. As of now there are 2 areas that we'd like to look more closely into:
 - windows runners (we already had them set up at the beginning so it's just a matter of resurrecting the configuration)
 - decreasing boot time (currently the runners take up to 2 minutes to boot up)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,6 +64,8 @@ We've been focusing on Kubo/Boxo developers in H1 2023. In H2, we'd like to work
 
 ## Explore DX of Building on IPFS Stack
 
+A major push around debuggability within our stack is expected to happen. This is a great opportunity to kick start a joint effort between Kubo, Helia, IPDX, and probelab. 
+
 Through our work on Gateway Conformance we discovered that building on IPFS stack is not easy, even for people close to the ecosystem. We'd like to start a standalone project that would help us explore this further. The very rough game plan is:
 1. Start a simple project that cuts through all the layers of IPFS stack (working idea - decentralised DropBox).
 2. Consume the publicly available documentation to implement the project.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,7 +55,8 @@ As one of the most under-resourced projects within IP Stewards group, it is the 
 ## Improve the Day to Day of Kubo/Boxo Developer
 
 We've been focusing on Kubo/Boxo developers in H1 2023. In H2, we'd like to work on the work items that we identified throughout the process. The main projects we envision are:
-- create a general solution for identifyin flaky tests within Go ecosystem
+- create a general solution for identifying flaky tests within Go ecosystem
+- create a general solution for [enforcing constraints on dependencies within Go ecosystem](https://github.com/pl-strflt/ipdx/issues/80)
 - automate CHANGELOG update reminders
 - fix the shortcomings of testing and coverage at the cross section of Kubo and Boxo
 - deprecate sharness tests

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,7 +46,7 @@ In August, we're going to release new version of Unified CI with Go 1.21 support
 - allowing configurability through dot files
 - simplifying enrollment with invite to deploy strategy
 
-All of the above will make Unified CI more robust, easier to manage and it will increase it chances to last for another couple of years. Moreover, it will open up doors for even more automation across hundreds of repositories, like using dependabot for Unified CI updates for example.
+All of the above will make Unified CI more robust, easier to manage and it will increase it chances to last for another couple of years. Moreover, it will open up doors for even more automation across hundreds of repositories, like using dependabot (instead of web3-bot that has to be maintained by IPDX) for Unified CI updates for example.
 
 ## Immerse Into the Day to Day of IP JS Developer
 


### PR DESCRIPTION
This PR adds https://github.com/pl-strflt/ipdx/issues/81 to the repository as a markdown file. We think it's easier to collaborate on the roadmap if we can comment on any particular line and leave suggestions. The markdown file will be the main source of truth.

This PR also adds automation which, on push to main, reads through the markdown file and creates/updates issues accordingly. The issues will link back to the source of truth. The automation will only update the issue body after the first encountered line separator (`---`) - this will allow users to maintain part of the issue content manually if needed.

This builds on Laurent's experience with ROADMAP handling in testground org.

###### Testing

- [x] test the roadmap workflow in another repository (https://github.com/galargh/.github/actions/runs/5456474641 + https://github.com/galargh/.github/issues/52)